### PR TITLE
UIImage remove cached image

### DIFF
--- a/UIImage+BBlock.h
+++ b/UIImage+BBlock.h
@@ -24,5 +24,6 @@ The `UIImage` is cached in an `NSCache` with the identifier provided. */
 + (UIImage *)imageWithIdentifier:(NSString *)identifier forSize:(CGSize)size andDrawingBlock:(void(^)())drawingBlock;
 + (UIImage *)imageWithIdentifier:(NSString *)identifier opaque:(BOOL)opaque forSize:(CGSize)size andDrawingBlock:(void(^)())drawingBlock;
 + (void)deCacheImageWithIdentifier:(NSString*)identifier;
++(void)deCacheAllImages;
 
 @end

--- a/UIImage+BBlock.m
+++ b/UIImage+BBlock.m
@@ -41,6 +41,8 @@
     UIImage *image = [[self drawingCache] objectForKey:identifier];
     if(image == nil && (image = [self imageForSize:size opaque:opaque withDrawingBlock:drawingBlock])){
         [[self drawingCache] setObject:image forKey:identifier];
+    } else {
+        NSLog(@"using cached image %@", identifier);
     }
     return image;
 }
@@ -50,9 +52,13 @@
 }
 
 + (void)deCacheImageWithIdentifier:(NSString*)identifier {
-    NSLog(@"decaching image");
+    //NSLog(@"decaching image");
     [[self drawingCache] removeObjectForKey:identifier];
     
+}
+
++(void)deCacheAllImages {
+    [[self drawingCache] removeAllObjects];
 }
 
 @end


### PR DESCRIPTION
support for removing previously cached images in UIImage category:

```
+ (void)deCacheImageWithIdentifier:(NSString*)identifier;
```
