### PR TITLE
bug fix for empty handler

### DIFF
--- a/Categories/AppKit/NSAlert+BBlock.m
+++ b/Categories/AppKit/NSAlert+BBlock.m
@@ -20,7 +20,7 @@ static char BBlockSheetKey;
 - (void)_alertDidEnd:(NSAlert *)alert returnCode:(NSInteger)returnCode contextInfo:(void *)contextInfo {
     void (^handler)(NSInteger returnCode) = objc_getAssociatedObject(self, &BBlockSheetKey);
     [alert.window orderOut:nil];
-    handler(returnCode);
+    if (handler) handler(returnCode);
     objc_setAssociatedObject(self, &BBlockSheetKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
 }
 @end

--- a/Categories/AppKit/NSApplication+BBlock.m
+++ b/Categories/AppKit/NSApplication+BBlock.m
@@ -31,7 +31,7 @@ static char BBlockSheetKey;
     
     void (^handler)(NSInteger returnCode) = objc_getAssociatedObject(self, &BBlockSheetKey);
     [sheet orderOut:nil];
-    handler(returnCode);
+    if (handler) handler(returnCode);
     objc_setAssociatedObject(self, &BBlockSheetKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
 }
 


### PR DESCRIPTION
This is a bug fix for a method I provided some weeks ago crashing if a valid handler block is not submitted.
